### PR TITLE
Fixing deprecation message.

### DIFF
--- a/lib/legacy-table.js
+++ b/lib/legacy-table.js
@@ -5,7 +5,7 @@ var Promise    = require('ember-cli/lib/ext/promise');
 
 module.exports = CoreObject.extend({
   init: function(plugin, revisions) {
-    this._super.init && this._super.init.apply(this, arguments);
+    this._super(plugin, revisions);
 
     this._plugin = plugin;
     this.revisions = revisions;

--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -7,7 +7,7 @@ var Promise    = require('ember-cli/lib/ext/promise');
 
 module.exports = CoreObject.extend({
   init: function(plugin, revisions) {
-    this._super.init && this._super.init.apply(this, arguments);
+    this._super(plugin, revisions);
 
     this._plugin = plugin;
     this.revisions = revisions;


### PR DESCRIPTION
## What Changed & Why

this._super is deprecated

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call this._super(), addon: `undefined`
    at Object.<anonymous> (app/node_modules/ember-cli-deploy-display-revisions/lib/scm-table.js:8:29)
```
