### PR TITLE
Allow revision-data: scm: null

### DIFF
--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -64,9 +64,9 @@ module.exports = CoreObject.extend({
 
       var row = [
         ((revision.active) ? '> ' : '  ') + data.revisionKey,
-        data.scm.sha.substr(0,8),
-        data.scm.email,
-        data.scm.branch,
+        data.scm && data.scm.sha.substr(0,8),
+        data.scm && data.scm.email,
+        data.scm && data.scm.branch,
       ];
 
       if (this._isWide()) {


### PR DESCRIPTION
## What Changed & Why
when the new data format is used it is still possible to have no scm data when `revision-data.scm` is set to `null`. which crashed displaying revisions
