### PR TITLE
Switch from Moment to Luxon

### DIFF
--- a/lib/legacy-table.js
+++ b/lib/legacy-table.js
@@ -1,4 +1,4 @@
-let moment = require('moment');
+let { DateTime } = require('luxon');
 let CoreObject = require('core-object');
 
 module.exports = CoreObject.extend({
@@ -38,7 +38,7 @@ module.exports = CoreObject.extend({
       let value = revision[key.name] ? revision[key.name] : "";
 
       if(key.name === 'timestamp') {
-        value = moment(value).format("YYYY/MM/DD HH:mm:ss");
+        value = DateTime.fromMillis(value).toFormat("yyyy/MM/dd HH:mm:ss");
       }
 
       if(key.maxLength !== -1) {

--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -1,5 +1,5 @@
 const Table = require('cli-table3');
-const moment = require('moment');
+const { DateTime } = require('luxon');
 const CoreObject = require('core-object');
 const RSVP = require('rsvp');
 
@@ -70,7 +70,7 @@ module.exports = CoreObject.extend({
       ];
 
       if (this._isWide()) {
-        let value = moment(data.timestamp).format("YYYY/MM/DD HH:mm:ss");
+        let value = DateTime.fromMillis(data.timestamp).toFormat('yyyy/MM/dd HH:mm:ss');
         row.push(value);
       }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cli-table3": "^0.6.0",
     "core-object": "^3.1.5",
     "ember-cli-deploy-plugin": "^0.2.3",
-    "moment": "^2.25.3",
+    "luxon": "^1.25.0",
     "rsvp": "^4.8.5"
   },
   "devDependencies": {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const moment = require('moment');
+const { DateTime } = require('luxon');
 const chai  = require('chai');
 const chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
@@ -198,10 +198,10 @@ describe('displayRevisions plugin', function() {
       assert.equal(messages.length, 0);
     });
 
-    it('transforms timestamps to human-readable dates (YYYY/MM/DD HH:mm:ss)', function() {
+    it('transforms timestamps to human-readable dates (yyyy/MM/dd HH:mm:ss)', function() {
       plugin.displayRevisions(context);
-      let expectedFormat = ('YYYY/MM/DD HH:mm:ss');
-      let expectedDate   = moment(1438232435000).format(expectedFormat);
+      let expectedFormat = ('yyyy/MM/dd HH:mm:ss');
+      let expectedDate   = DateTime.fromMillis(1438232435000).toFormat(expectedFormat);
 
       let messages = mockUi.messages.reduce(function(previous, current) {
         if (current.indexOf(expectedDate) !== -1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4725,6 +4725,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.25.0.tgz#d86219e90bc0102c0eb299d65b2f5e95efe1fe72"
+  integrity sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -5112,11 +5117,6 @@ mocha@^7.1.2:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
-
-moment@^2.25.3:
-  version "2.25.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.3.tgz#252ff41319cf41e47761a1a88cab30edfe9808c0"
-  integrity sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==
 
 morgan@^1.9.1:
   version "1.10.0"


### PR DESCRIPTION
## What Changed & Why

Though hugely popular, Moment.js has [announced a shift into maintenance mode](https://momentjs.com/docs/#/-project-status/):

> We now generally consider Moment to be a legacy project in maintenance mode. It is not dead, but it is indeed done.

Moment's top recommendation for a replacement is [Luxon](https://moment.github.io/luxon/) - which happens to also exist under the Moment GitHub org and has a similar API to Moment but is a bit more modern in its approach. Since the usage of Moment in this addon is limited, the transition is pretty straightforward.

## PR Checklist
- [x] Update tests