### PR TITLE
Fall back to ISO if timestamp is not milliseconds

### DIFF
--- a/lib/legacy-table.js
+++ b/lib/legacy-table.js
@@ -38,7 +38,9 @@ module.exports = CoreObject.extend({
       let value = revision[key.name] ? revision[key.name] : "";
 
       if(key.name === 'timestamp') {
-        value = DateTime.fromMillis(value).toFormat("yyyy/MM/dd HH:mm:ss");
+        // ember-cli-deploy-revision-data uses ISO timestamps, so fall back to ISO if not milliseconds
+        let dt = typeof value === 'number' ? DateTime.fromMillis(value) : DateTime.fromISO(value);
+        value = dt.toFormat("yyyy/MM/dd HH:mm:ss");
       }
 
       if(key.maxLength !== -1) {

--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -70,7 +70,10 @@ module.exports = CoreObject.extend({
       ];
 
       if (this._isWide()) {
-        let value = DateTime.fromMillis(data.timestamp).toFormat('yyyy/MM/dd HH:mm:ss');
+        let { timestamp } = data;
+        // ember-cli-deploy-revision-data uses ISO timestamps, so fall back to ISO if not milliseconds
+        let dt = typeof timestamp === 'number' ? DateTime.fromMillis(timestamp) : DateTime.fromISO(timestamp);
+        let value = dt.toFormat('yyyy/MM/dd HH:mm:ss');
         row.push(value);
       }
 


### PR DESCRIPTION
## What Changed & Why

#39 switched from Moment to Luxon for timestamp formatting. This plugin's documentation specifies that timestamps [should be in milliseconds since epoch](https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions#passing-revisions), but ember-cli-deploy-revision-data [uses ISO 8601 for timestamps](https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/blob/b71afd74ca443fb0be36e1eb0a66461abf981eda/lib/data-generators/git-commit.js#L21) so any index plugin relying on ecd-revision-data to create the timestamp is likely to provide ISO 8601 instead.

Moment was much more forgiving than Luxon is regarding incoming format. To cover this (seemingly common) additional format, this PR checks to see if the timestamp is a number. If so, it assumes milliseconds as documented. If not, it falls back to the ISO 8601 format that ecd-revision-data provides.

## Related issues

Resolves #40 

## People

@BnitoBzh @achambers 