### PR TITLE
Luxon Take 3: Use fromJSDate instead of fromISO for ember-cli-deploy-revision-data

### DIFF
--- a/lib/legacy-table.js
+++ b/lib/legacy-table.js
@@ -38,8 +38,8 @@ module.exports = CoreObject.extend({
       let value = revision[key.name] ? revision[key.name] : "";
 
       if(key.name === 'timestamp') {
-        // ember-cli-deploy-revision-data uses ISO timestamps, so fall back to ISO if not milliseconds
-        let dt = typeof value === 'number' ? DateTime.fromMillis(value) : DateTime.fromISO(value);
+        // ember-cli-deploy-revision-data provides a JS Date object, so fall back to that if not milliseconds
+        let dt = typeof value === 'number' ? DateTime.fromMillis(value) : DateTime.fromJSDate(value);
         value = dt.toFormat("yyyy/MM/dd HH:mm:ss");
       }
 

--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -71,8 +71,8 @@ module.exports = CoreObject.extend({
 
       if (this._isWide()) {
         let { timestamp } = data;
-        // ember-cli-deploy-revision-data uses ISO timestamps, so fall back to ISO if not milliseconds
-        let dt = typeof timestamp === 'number' ? DateTime.fromMillis(timestamp) : DateTime.fromISO(timestamp);
+        // ember-cli-deploy-revision-data provides a JS Date object, so fall back to that if not milliseconds
+        let dt = typeof timestamp === 'number' ? DateTime.fromMillis(timestamp) : DateTime.fromJSDate(timestamp);
         let value = dt.toFormat('yyyy/MM/dd HH:mm:ss');
         row.push(value);
       }


### PR DESCRIPTION
## What Changed & Why

I made a mistake in #41 by assuming that since `console.log` was spitting out `2020-10-26T16:01:36.000Z` for timestamps provided from ember-cli-deploy-revision-data, those were ISO timestamps. It turns out that they are JS Date objects and `console.log` transforms them into that format automatically 🤦🏻‍♂️

Instead of trying to parse ISO if we don't have milliseconds, we should instead fall back to JS Date objects. Since this fallback was added especially for ember-cli-deploy-revision-data and its central place in the e-c-d ecosystem, we'll assume this format if we don't have milliseconds as this plugin documents.

## Related issues

https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/pull/41#issuecomment-716629232

## People

@koendehondt @achambers 