### PR TITLE
docs: add md in yarn test

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Omitted keys are not displayed in listing the results.
 
 ## Tests
 
-* yarn test
+* `yarn test`
 
 ## Why `ember build` and `ember test` don't work
 


### PR DESCRIPTION
## What Changed & Why
Hi, I just added a markdown rule in yarn test, I thought all your readme was awesome with markdown rules but I thought maybe this was missing

## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ X] Prefix documentation-only commits with [DOC]
