### PR TITLE
Convert timestamp to JS Date object

### DIFF
--- a/lib/legacy-table.js
+++ b/lib/legacy-table.js
@@ -39,7 +39,7 @@ module.exports = CoreObject.extend({
 
       if(key.name === 'timestamp') {
         // ember-cli-deploy-revision-data provides a JS Date object, so fall back to that if not milliseconds
-        let dt = typeof value === 'number' ? DateTime.fromMillis(value) : DateTime.fromJSDate(value);
+        let dt = typeof value === 'number' ? DateTime.fromMillis(value) : DateTime.fromJSDate(new Date(value));
         value = dt.toFormat("yyyy/MM/dd HH:mm:ss");
       }
 

--- a/lib/scm-table.js
+++ b/lib/scm-table.js
@@ -72,7 +72,7 @@ module.exports = CoreObject.extend({
       if (this._isWide()) {
         let { timestamp } = data;
         // ember-cli-deploy-revision-data provides a JS Date object, so fall back to that if not milliseconds
-        let dt = typeof timestamp === 'number' ? DateTime.fromMillis(timestamp) : DateTime.fromJSDate(timestamp);
+        let dt = typeof timestamp === 'number' ? DateTime.fromMillis(timestamp) : DateTime.fromJSDate(new Date(timestamp));
         let value = dt.toFormat('yyyy/MM/dd HH:mm:ss');
         row.push(value);
       }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -164,8 +164,8 @@ describe('displayRevisions plugin', function() {
         },
         revisions: [
           { revision: "rev:abcdef", timestamp: 1438232435000, deployer: "My Hamster"},
-          { revision: "rev:defghi", timestamp: 1032123125000, deployer: "My Hamster", active: true},
-          { revision: "rev:jklmno", timestamp: 1032123128000, deployer: "My Hamster"},
+          { revision: "rev:defghi", timestamp: '2002-09-15T20:52:05.000Z', deployer: "My Hamster", active: true},
+          { revision: "rev:jklmno", timestamp: new Date(1032123128000), deployer: "My Hamster"},
           { revision: "rev:qrstuv", timestamp: 1032123155000, deployer: "My Hamster"},
           { revision: "rev:xyz123", timestamp: 1032123123000, deployer: "My Hamster"}
         ]
@@ -198,10 +198,40 @@ describe('displayRevisions plugin', function() {
       assert.equal(messages.length, 0);
     });
 
-    it('transforms timestamps to human-readable dates (yyyy/MM/dd HH:mm:ss)', function() {
+    it('transforms millisecond timestamps to human-readable dates (yyyy/MM/dd HH:mm:ss)', function() {
       plugin.displayRevisions(context);
       let expectedFormat = ('yyyy/MM/dd HH:mm:ss');
       let expectedDate   = DateTime.fromMillis(1438232435000).toFormat(expectedFormat);
+
+      let messages = mockUi.messages.reduce(function(previous, current) {
+        if (current.indexOf(expectedDate) !== -1) {
+          previous.push(current);
+        }
+
+        return previous;
+      }, []);
+      assert.equal(messages.length, 1);
+    });
+
+    it('transforms ISO string timestamps to human-readable dates (yyyy/MM/dd HH:mm:ss)', function() {
+      plugin.displayRevisions(context);
+      let expectedFormat = ('yyyy/MM/dd HH:mm:ss');
+      let expectedDate   = DateTime.fromISO('2002-09-15T20:52:05.000Z').toFormat(expectedFormat);
+
+      let messages = mockUi.messages.reduce(function(previous, current) {
+        if (current.indexOf(expectedDate) !== -1) {
+          previous.push(current);
+        }
+
+        return previous;
+      }, []);
+      assert.equal(messages.length, 1);
+    });
+
+    it('transforms JS Date object timestamps to human-readable dates (yyyy/MM/dd HH:mm:ss)', function() {
+      plugin.displayRevisions(context);
+      let expectedFormat = ('yyyy/MM/dd HH:mm:ss');
+      let expectedDate   = DateTime.fromJSDate(new Date(1032123128000)).toFormat(expectedFormat);
 
       let messages = mockUi.messages.reduce(function(previous, current) {
         if (current.indexOf(expectedDate) !== -1) {


### PR DESCRIPTION
## What Changed & Why
In the event that the `timestamp` from the revision data is not in milliseconds it will either be an ISOString _or_ a JS Date object. To make sure we correctly parse both of those scenarios we first convert the `timestamp` into a native Date object using `new Date()`. This makes it compatible with both timestamp formats.

## Related issues
[List displays Invalid DateTime for Deploy time column #69](https://github.com/ember-cli-deploy/ember-cli-deploy-display-revisions/issues/69
)

## PR Checklist
- [x] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)
